### PR TITLE
generate 1 ca

### DIFF
--- a/envoy.yaml
+++ b/envoy.yaml
@@ -24,6 +24,18 @@ static_resources:
                           route: { cluster: upstream_service }
                 http_filters:
                   - name: envoy.filters.http.router
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              require_client_certificate: true
+              common_tls_context:
+                tls_certificates:
+                  - certificate_chain: {filename: /etc/envoy/certs/server.pem}
+                    private_key: {filename: /etc/envoy/certs/server.key}
+                validation_context:
+                  trusted_ca: {filename: /etc/envoy/certs/rootCA1.pem}
+
   clusters:
     - name: upstream_service
       connect_timeout: 1s
@@ -41,6 +53,7 @@ static_resources:
           path: '/healthz'
       common_lb_config:
         healthy_panic_threshold: {}
+
       load_assignment:
         cluster_name: upstream_service
         endpoints:

--- a/mtls/certs/create-certs.sh
+++ b/mtls/certs/create-certs.sh
@@ -2,7 +2,7 @@
 
 # Create 2 root CA's
 openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -out rootCA1.pem -keyout rootCA1.key -subj "/C=US/CN=rootca.io"
-openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -out rootCA2.pem -keyout rootCA2.key -subj "/C=US/CN=rootca2.io"
+#openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -out rootCA2.pem -keyout rootCA2.key -subj "/C=US/CN=rootca2.io"
 
 # Sign a server cert w/ rootCA1
 openssl genrsa -out server.key 2048
@@ -16,10 +16,10 @@ openssl req -new -key clientone.key -out clientone.csr -subj "/C=US/CN=clientone
 openssl x509 -req -in clientone.csr -CA rootCA1.pem -CAkey rootCA1.key -CAcreateserial -out clientone.pem -days 3650 -sha256
 rm clientone.csr
 
-openssl genrsa -out clienttwo.key 2048
-openssl req -new -key clienttwo.key -out clienttwo.csr -subj "/C=US/CN=clienttwo"
-openssl x509 -req -in clienttwo.csr -CA rootCA2.pem -CAkey rootCA2.key -CAcreateserial -out clienttwo.pem -days 3650 -sha256
-rm clienttwo.csr
+#openssl genrsa -out clienttwo.key 2048
+#openssl req -new -key clienttwo.key -out clienttwo.csr -subj "/C=US/CN=clienttwo"
+#openssl x509 -req -in clienttwo.csr -CA rootCA2.pem -CAkey rootCA2.key -CAcreateserial -out clienttwo.pem -days 3650 -sha256
+#rm clienttwo.csr
 
 # Concat both CA's into one file:
-cat rootCA1.pem rootCA2.pem > rootCA.pem
+#cat rootCA1.pem rootCA2.pem > rootCA.pem


### PR DESCRIPTION
Runbook:
- Run `create-certs.sh` in `mtls/certs` folder
- Run `docker compose up` in the project root folder
- Run `curl -k https://localhost:9786/app --cert mtls/certs/clientone.pem --key mtls/certs/clientone.key  -v` in the project root folder.